### PR TITLE
Change encoder to svt-av1.

### DIFF
--- a/makeavif.py
+++ b/makeavif.py
@@ -114,11 +114,11 @@ class makeavif:
         ff_pixfmt_a='gray{D}'.format(D=(str(self.bits) if self.bits>8 else '')) + ('le' if self.bits>8 else '')
         coffs = (-2 if self.subs_w and self.subs_h else 1)
         # Actually the color_primaries should be IEC 61966-2-1 (aka sRGB or sYCC), but ffmpeg does not accept this value. And at least for color_primaries, bt709 strictly equal to IEC 61966-2-1 ,so it is chosen.
-        self.ff_cmd_img=r'ffmpeg -hide_banner -r 1 -i "{INP}" -vf {PD}{SF},format={PF} -qp {QP} -frames 1 -c:v librav1e -tile-columns 2 -tile-rows 2 -color_range pc -color_trc iec61966-2-1 -color_primaries bt709 -rav1e-params speed={S}:still_picture=true "%temp%\make.avif.{PID}.ivf" -y'.format(QP=self.q,S=self.speed,INP=self.in_fp,PD=pad,SF=scale_filter,MAT_L=self.mat_l,PF=ff_pixfmt,PID=self.pid)
+        self.ff_cmd_img=r'ffmpeg -hide_banner -r 1 -i "{INP}" -vf {PD}{SF},format={PF} -qp {QP} -frames 1 -c:v libsvtav1 -tile-columns 2 -tile-rows 2 -color_range pc -color_trc iec61966-2-1 -color_primaries bt709 -preset {S} "%temp%\make.avif.{PID}.ivf" -y'.format(QP=self.q,S=self.speed,INP=self.in_fp,PD=pad,SF=scale_filter,MAT_L=self.mat_l,PF=ff_pixfmt,PID=self.pid)
 
         self.m4b_cmd_img=r'cd /d %temp% && mp4box -add-image "make.avif.{PID}.ivf":primary:image-size={WxH}{ICC} -brand avif -new "{OUT}" && del "make.avif.{PID}.ivf"'.format(OUT=self.out_fp,ICC=icc_opt,PID=self.pid,WxH=str(self.probe_res_w)+'x'+str(self.probe_res_h))
 
-        self.ff_cmd_a=r'ffmpeg -hide_banner -r 1 -i "{INP}" -vf {PD}extractplanes=a,format={PF} -qp {QP} -frames 1 -c:v librav1e -tile-columns 2 -tile-rows 2 -color_range pc -color_trc iec61966-2-1 -color_primaries bt709 -rav1e-params speed={S}:still_picture=true "%temp%\make.avif.alpha.{PID}.ivf" -y'.format(QP=self.q,S=self.speed,INP=self.in_fp,PD=pad,SF=':'.join(scale_filter.split(':')[:-1]),MAT_L=self.mat_l,PF=ff_pixfmt_a,PID=self.pid)
+        self.ff_cmd_a=r'ffmpeg -hide_banner -r 1 -i "{INP}" -vf {PD}extractplanes=a,format={PF} -qp {QP} -frames 1 -c:v libsvtav1 -tile-columns 2 -tile-rows 2 -color_range pc -color_trc iec61966-2-1 -color_primaries bt709 -preset {S} "%temp%\make.avif.alpha.{PID}.ivf" -y'.format(QP=self.q,S=self.speed,INP=self.in_fp,PD=pad,SF=':'.join(scale_filter.split(':')[:-1]),MAT_L=self.mat_l,PF=ff_pixfmt_a,PID=self.pid)
 
         self.m4b_cmd_a=r'cd /d %temp% && mp4box -add-image "make.avif.{PID}.ivf":primary:image-size={WxH}{ICC}  -add-image "make.avif.alpha.{PID}.ivf":ref=auxl,1:alpha:image-size={WxH} -brand avif -new "{OUT}" && del "make.avif.alpha.{PID}.ivf"'.format(OUT=self.out_fp,PID=self.pid,ICC=icc_opt,WxH=str(self.probe_res_w)+'x'+str(self.probe_res_h))
 

--- a/makeavif.py
+++ b/makeavif.py
@@ -10,7 +10,7 @@ class args:
 
 
 class makeavif:
-    def __init__(self,in_fp,out_fp,q=50,speed=4,delsrc=False,sws=False,alpha=False,noalpha=False,noicc=False,mat=None,depth=10,sample='444',pid=choice(range(1000,10000))):
+    def __init__(self,in_fp,out_fp,q=50,speed=4,delsrc=False,sws=False,alpha=False,noalpha=False,noicc=False,mat=None,depth=10,sample='420',pid=choice(range(1000,10000))):
         self.in_fp = in_fp
         self.out_fp = out_fp
         self.q = q
@@ -158,7 +158,7 @@ if __name__ == '__main__':
     #New version of libheif seems to decode with matrixs accordingly, so I think it's better to use modern bt709 as default.
     parser.add_argument('--mat',type=str,required=False,help='Matrix used to convert RGB input file, should be either bt709 or bt601 currently. If a input file is in YUV, it\'s original matrix will be "preserved". ',default=None)
     parser.add_argument('--depth',type=int,required=False,help='Bitdepth for avif-yuv output, default 10.',default=10)
-    parser.add_argument('--sample',type=str,required=False,help='Chroma subsumpling for avif-yuv output, default "444"',default='444')
+    parser.add_argument('--sample',type=str,required=False,help='Chroma subsumpling for avif-yuv output, default "420". note: libsvtav1 in ffmpeg only supports 420 currently',default='420')
     parser.add_argument('INPUTFILE',type=str,help='Input file.',nargs='+')
     parser.parse_args(sys.argv[1:],args)
     pid = os.getpid()

--- a/makeavif.py
+++ b/makeavif.py
@@ -10,7 +10,7 @@ class args:
 
 
 class makeavif:
-    def __init__(self,in_fp,out_fp,q=80,speed=4,delsrc=False,sws=False,alpha=False,noalpha=False,noicc=False,mat=None,depth=10,sample='444',pid=choice(range(1000,10000))):
+    def __init__(self,in_fp,out_fp,q=50,speed=4,delsrc=False,sws=False,alpha=False,noalpha=False,noicc=False,mat=None,depth=10,sample='444',pid=choice(range(1000,10000))):
         self.in_fp = in_fp
         self.out_fp = out_fp
         self.q = q
@@ -146,7 +146,7 @@ class makeavif:
 if __name__ == '__main__':
     #Arguments, ordinary stuff I guess.
     parser = argparse.ArgumentParser(description='avif encode script using ffmpeg & mp4box.',formatter_class=argparse.RawTextHelpFormatter)
-    parser.add_argument('-q',type=int,required=False,help='Quality(cqp),range(0-255), default 80.',default=80)
+    parser.add_argument('-q',type=int,required=False,help='Quality(cqp),range(0-63), default 50.',default=50)
     parser.add_argument('-speed',type=int,required=False,help='Speed level (0 is best quality, 10 is fastest) default 4',default=4)
     parser.add_argument('-o',type=str,required=False,help='Output(s), default input full name (ext. incl.) + ".avif".',nargs='*')
     parser.add_argument('-s',required=False,help='Silent mode, disables "enter to exit".',action='store_true')

--- a/makeavif.py
+++ b/makeavif.py
@@ -114,11 +114,11 @@ class makeavif:
         ff_pixfmt_a='gray{D}'.format(D=(str(self.bits) if self.bits>8 else '')) + ('le' if self.bits>8 else '')
         coffs = (-2 if self.subs_w and self.subs_h else 1)
         # Actually the color_primaries should be IEC 61966-2-1 (aka sRGB or sYCC), but ffmpeg does not accept this value. And at least for color_primaries, bt709 strictly equal to IEC 61966-2-1 ,so it is chosen.
-        self.ff_cmd_img=r'ffmpeg -hide_banner -r 1 -i "{INP}" -vf {PD}{SF},format={PF} -qp {QP} -frames 1 -c:v libsvtav1 -tile-columns 2 -tile-rows 2 -color_range pc -color_trc iec61966-2-1 -color_primaries bt709 -preset {S} "%temp%\make.avif.{PID}.ivf" -y'.format(QP=self.q,S=self.speed,INP=self.in_fp,PD=pad,SF=scale_filter,MAT_L=self.mat_l,PF=ff_pixfmt,PID=self.pid)
+        self.ff_cmd_img=r'ffmpeg -hide_banner -r 1 -i "{INP}" -vf {PD}{SF},format={PF} -vbsf av1_metadata=color_range=pc -qp {QP} -frames 1 -c:v libsvtav1 -tile-columns 2 -tile-rows 2 -color_range pc -color_trc iec61966-2-1 -color_primaries bt709 -preset {S} "%temp%\make.avif.{PID}.ivf" -y'.format(QP=self.q,S=self.speed,INP=self.in_fp,PD=pad,SF=scale_filter,MAT_L=self.mat_l,PF=ff_pixfmt,PID=self.pid)
 
         self.m4b_cmd_img=r'cd /d %temp% && mp4box -add-image "make.avif.{PID}.ivf":primary:image-size={WxH}{ICC} -brand avif -new "{OUT}" && del "make.avif.{PID}.ivf"'.format(OUT=self.out_fp,ICC=icc_opt,PID=self.pid,WxH=str(self.probe_res_w)+'x'+str(self.probe_res_h))
 
-        self.ff_cmd_a=r'ffmpeg -hide_banner -r 1 -i "{INP}" -vf {PD}extractplanes=a,format={PF} -qp {QP} -frames 1 -c:v libsvtav1 -tile-columns 2 -tile-rows 2 -color_range pc -color_trc iec61966-2-1 -color_primaries bt709 -preset {S} "%temp%\make.avif.alpha.{PID}.ivf" -y'.format(QP=self.q,S=self.speed,INP=self.in_fp,PD=pad,SF=':'.join(scale_filter.split(':')[:-1]),MAT_L=self.mat_l,PF=ff_pixfmt_a,PID=self.pid)
+        self.ff_cmd_a=r'ffmpeg -hide_banner -r 1 -i "{INP}" -vf {PD}extractplanes=a,format={PF} -vbsf av1_metadata=color_range=pc -qp {QP} -frames 1 -c:v libsvtav1 -tile-columns 2 -tile-rows 2 -color_range pc -color_trc iec61966-2-1 -color_primaries bt709 -preset {S} "%temp%\make.avif.alpha.{PID}.ivf" -y'.format(QP=self.q,S=self.speed,INP=self.in_fp,PD=pad,SF=':'.join(scale_filter.split(':')[:-1]),MAT_L=self.mat_l,PF=ff_pixfmt_a,PID=self.pid)
 
         self.m4b_cmd_a=r'cd /d %temp% && mp4box -add-image "make.avif.{PID}.ivf":primary:image-size={WxH}{ICC}  -add-image "make.avif.alpha.{PID}.ivf":ref=auxl,1:alpha:image-size={WxH} -brand avif -new "{OUT}" && del "make.avif.alpha.{PID}.ivf"'.format(OUT=self.out_fp,PID=self.pid,ICC=icc_opt,WxH=str(self.probe_res_w)+'x'+str(self.probe_res_h))
 


### PR DESCRIPTION
svt-av1 is now the "major encoder project" of aom, and have better quality (and even speed) than rav1e nowadays, but thanks to the poor implementation in ffmpeg, its ability may be limited.
Perhaps standalone svt-av1 encoder cli tool will do better job, and some tweaks might needed because there is no still picture presets for svt-av1 (seems like).
But I still prefer heic, so anyways...

The compatibility you have with alpha plane is a bug or something of mp4box's stable release. Dev builds of mp4box had solved this problem.
[alpha_example.zip](https://github.com/Nuevo009/makeheic-avif/files/7656831/alpha_example.zip)


_(personal opinion: no, jxl is not much better than heic except for losslessly re-compress jpeg, the decoding speed is different between softwares, but I get both heic>jxl and jxl>heic results. and fine tuned x265 heic is better than avif and jxl._